### PR TITLE
chore: Remove unsuitable message

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -50,7 +50,6 @@ const MESSAGES = [
   "Let the modules hit the floor!",
   "Play sth nice!",
   "Let's roll!",
-  "Stop refreshing, just click me!",
   "Why so silent?",
   "You want to click here.",
   "Hit me!",


### PR DESCRIPTION
This message may appear whenever one loads up the page, not just on refresh. This was a dev thing when we just used to refresh the page a lot to test out messages.